### PR TITLE
fix: cleanup does not run with DISABLE_RUNNER_CLEANUP=false

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,20 +20,27 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      - name: '⚙️ Use Node.js'
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          check-latest: true
-          cache: 'npm'
-
-      - name: '⛓️ Install dependencies'
-        run: npm ci --no-optional --no-audit --prefer-offline --progress=false
-
       - name: '📝 Creating files and folders'
         run: ./test/add_files.sh
 
       - name: '⚙️ Run action'
+        uses: ./
+
+      - name: '✅ Test if workspace is empty'
+        shell: bash
+        run: |
+          if [ "$(ls -A .)" ]; then
+            echo "Workspace is not Empty"
+            exit 1
+          fi
+
+      - name: '☁️ Checkout repository'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: '⚙️ Run action with DISABLE_RUNNER_CLEANUP set to true'
         env:
           DISABLE_RUNNER_CLEANUP: true
         uses: ./
@@ -48,7 +55,9 @@ jobs:
             exit 1
           fi
 
-      - name: '⚙️ Run action'
+      - name: '⚙️ Run action with DISABLE_RUNNER_CLEANUP set to false'
+        env:
+          DISABLE_RUNNER_CLEANUP: false
         uses: ./
 
       - name: '✅ Test if workspace is empty'

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ runs:
     - id: step-1
       name: '🧹 Clean working directory'
       # If you want to disable the cleanup for e.g. debugging purpose, you can set the environment variable DISABLE_RUNNER_CLEANUP to true
-      if: ${{ always() && !env.DISABLE_RUNNER_CLEANUP}} # Run even if the job fails or is canceled
+      if: ${{ always() && env.DISABLE_RUNNER_CLEANUP != 'true' }} # Run even if the job fails or is canceled
       shell: bash
       # TODO: evaluate rm -rf "${{ github.workspace }}"
       run: |


### PR DESCRIPTION
Cleanup would never execute whenever DISABLE_RUNNER_CLEANUP was set, regardless of the value.
The action is now explicitly checking for DISABLE_RUNNER_CLEANUP not being set to `true`

Closes #111 